### PR TITLE
Fix: Ensure replay bot spawns reliably after map changes (final)

### DIFF
--- a/src/Plugin/Plugin.cs
+++ b/src/Plugin/Plugin.cs
@@ -12,6 +12,9 @@ public partial class SharpTimer
     {
         try
         {
+            if (Utils != null) Utils.LogDebug("OnMapStartHandler: Clearing replay bot trail and controller.");
+            ClearReplayBotTrail();
+            replayBotController = null;
             Server.NextFrame(() =>
             {
                 Utils.LogDebug("OnMapStart:");


### PR DESCRIPTION
This commit addresses an issue where the replay bot would not consistently spawn after a map change. This version ensures that `src/Features/ReplayUtils.cs` remains identical to its state prior to any edits in this session.

The fix is confined to `src/Plugin/Plugin.cs`:
- `replayBotController` and its associated trail are cleared at the very beginning of a new map load by adding `ClearReplayBotTrail();` and `replayBotController = null;` to the `OnMapStartHandler` method. This ensures the conditions for spawning the bot are correctly set for the new map.

All other attempted modifications to `src/Features/ReplayUtils.cs` have been reverted to ensure its integrity.